### PR TITLE
MAT-3943 Allow passing replacement assets for logos in new Footer

### DIFF
--- a/react/components/Footer/FooterUI.jsx
+++ b/react/components/Footer/FooterUI.jsx
@@ -18,6 +18,27 @@ const FooterUI = (props) => {
         : "mailto:QPPUserResearch@cms.hhs.gov?subject=Sign up for feedback sessions&body=Please let us know your role and how many Tax Identification Numbers (TINs) you represent. Don’t send us your actual TINs, that is confidential information that should not be shared with this email address. If you do not represent a practice, let us know what work you do in connection to QPP.";
     const [listServ, setListServ] = useState(false);
 
+    // Default footer assets
+    const assets = {
+        ...{
+            hhsLogo: (
+                <img
+                    className="hhs-logo"
+                    alt="Department of Health &amp; Human Services USA"
+                    src="/images/hhs-logo-black.svg"
+                />
+            ),
+            qppLogo: (
+                <img
+                    className="qpp-logo"
+                    src="/images/qpp_logo_rgb_color.png"
+                    alt="qpp logo"
+                />
+            ),
+        },
+        ...props.assets,
+    };
+
     const setLink = (link) => {
         return isIESupportPage ? "/" : link;
     };
@@ -236,18 +257,10 @@ const FooterUI = (props) => {
                         </div>
                         <div className="qpp-hhs-logo-container">
                             <div className="qpp-logo-container">
-                                <img
-                                    className="qpp-logo"
-                                    src="/images/qpp_logo_rgb_color.png"
-                                    alt="qpp logo"
-                                />
+                                {assets.qppLogo}
                             </div>
                             <div className="hhs-logo-container">
-                                <img
-                                    className="hhs-logo"
-                                    alt="Department of Health &amp; Human Services USA"
-                                    src="/images/hhs-logo-black.svg"
-                                />
+                                {assets.hhsLogo}
                                 <p>
                                     A federal government website managed and
                                     paid for by the U.S Centers for Medicare
@@ -276,6 +289,10 @@ FooterUI.propTypes = {
     isNewFooter: PropTypes.bool,
     isIESupportPage: PropTypes.bool,
     showHcdResearch: PropTypes.bool,
+    assets: PropTypes.shape({
+        hhsLogo: PropTypes.element,
+        qppLogo: PropTypes.element,
+    }),
 };
 
 export default FooterUI;

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@madie/madie-design-system",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "^2.13.0",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shared style guide across the Madie program.",
   "main": "dist/index.js",
   "homepage": "https://github.com/MeasureAuthoringTool/madie-design-system",

--- a/react/test/components/FooterUI.test.js
+++ b/react/test/components/FooterUI.test.js
@@ -57,6 +57,36 @@ describe("FooterUI", () => {
         const isFullWidthNode = ReactDOM.findDOMNode(isFullWidth);
         expect(ReactTestUtils.isDOMComponent(isFullWidthNode)).to.be.true;
     });
+
+    it("renders optional custom assets if passed", () => {
+        // Test render with default assets
+        const stockComponent = ReactTestUtils.renderIntoDocument(
+            <Wrapper>
+                <FooterUI isNewFooter={true} />
+            </Wrapper>
+        );
+        const defaultLogoNode =
+            ReactTestUtils.findRenderedDOMComponentWithClass(
+                stockComponent,
+                "hhs-logo"
+            );
+        expect(ReactTestUtils.isDOMComponent(defaultLogoNode)).to.be.true;
+
+        // Test render with custom asset
+        const assets = {
+            hhsLogo: <img src="/test-image.png" className="hhs-logo-custom" />,
+        };
+        const customAssetComponent = ReactTestUtils.renderIntoDocument(
+            <Wrapper>
+                <FooterUI isNewFooter={true} assets={assets} />
+            </Wrapper>
+        );
+        const customLogoNode = ReactTestUtils.findRenderedDOMComponentWithClass(
+            customAssetComponent,
+            "hhs-logo-custom"
+        );
+        expect(ReactTestUtils.isDOMComponent(customLogoNode)).to.be.true;
+    });
 });
 
 describe("renders the footer properly in the non-authenticated experience", () => {


### PR DESCRIPTION
Allows use of new footer with custom defined replacements for logos.