### PR TITLE
MAT-3366

### DIFF
--- a/react/components/MadieSpinner/MadieSpinner.stories.js
+++ b/react/components/MadieSpinner/MadieSpinner.stories.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withKnobs } from "@storybook/addon-knobs";
+import MadieSpinner from "./index";
+
+export default {
+    title: "MadieSpinner",
+    component: MadieSpinner,
+    decorators: [withKnobs],
+};
+
+const Wrapper = ({ children }) => (
+    <div className="qpp-u-padding--16" style={{ width: 300 }}>
+        {children}
+    </div>
+);
+
+Wrapper.propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node,
+};
+
+export const ExampleSpinner = () => (
+    <Wrapper>
+        <MadieSpinner />
+    </Wrapper>
+)
+
+ExampleSpinner.storyName = "example Madie Spinner";

--- a/react/components/MadieSpinner/index.jsx
+++ b/react/components/MadieSpinner/index.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { CircularProgress } from '@mui/material';
+import { makeStyles } from "@mui/styles";
+import PropTypes from "prop-types";
+
+// To change the spinner size you have to pass style props for height and width.
+const MadieSpinner = (props) => {
+    const useStyles = makeStyles({
+        svg: {
+            backgroundColor: 'transparent',
+            borderRadius: '100%',
+            // box shadow is our track. It needs to match the thickness of the svg element to look like it
+            // if we get a thickness value, we update our box shadow
+            boxShadow: `inset 0 0 0px ${props.thickness ? props.thickness : '7'}px #DDDDDD`,
+        },
+        circle: {
+            color: '#209FA6',
+            strokeLinecap: 'round',
+        }
+    });
+    const classes = useStyles();
+    return (
+    <CircularProgress
+        aria-label="loading-spinner"
+        classes={classes}
+        thickness={7}
+        style={{ height: 50, width: 50 }}
+        // Props overwrite whatever they want.
+        {...props}
+    />)
+}
+
+MadieSpinner.propTypes = {
+    thickness: PropTypes.number
+};
+
+export default MadieSpinner;

--- a/react/components/index.js
+++ b/react/components/index.js
@@ -9,6 +9,7 @@ import Footer from "./Footer/FooterUI";
 import Header from "./Header/HeaderUI";
 import InputLabel from "./InputLabel";
 import FormControlLabel from "./FormControlLabel";
+import MadieSpinner from './MadieSpinner';
 import Modal from "./Modal";
 import { Pagination } from "./Pagination";
 import SideNav from "./SideNav/UI/SideNavUI";
@@ -120,6 +121,7 @@ export {
     Icons,
     Infotip,
     Modal,
+    MadieSpinner,
     Pagination,
     Search,
     Select,

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@madie/madie-design-system",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "^2.13.0",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Shared style guide across the Madie program.",
   "main": "dist/index.js",
   "homepage": "https://github.com/MeasureAuthoringTool/madie-design-system",

--- a/react/test/components/MadieSpinner.test.js
+++ b/react/test/components/MadieSpinner.test.js
@@ -1,0 +1,25 @@
+import "@testing-library/jest-dom";
+import React from 'react';
+import { describe, expect, test } from "@jest/globals";
+import { act } from "react-dom/test-utils";
+import { render } from "@testing-library/react";
+import MadieSpinner from "../../components/MadieSpinner";
+
+describe("MadieSpinner", () => {
+    test("MadieSpinner exists and renders", async () => {
+        await act(async () => {
+            const { findByTestId } = render(
+                <MadieSpinner data-testid="test-spinner" thickness={8} style={{height: 50, width: 50}}/>
+            )
+            expect(await findByTestId('test-spinner')).toBeInTheDocument();
+        })
+    })
+    test("MadieSpinner renders with no props", async () => {
+        await act(async () => {
+            const { findByTestId } = render(
+                <MadieSpinner data-testid="test-spinner" />
+            )
+            expect(await findByTestId('test-spinner')).toBeInTheDocument();
+        })
+    })
+})


### PR DESCRIPTION
Create a MadieSpinner reusable component that reskins the Material ui component for a spinner.

This spinner has some default values, but everything can be overridden by passing props as they take presedence.
The spinner is smart enough to automatically adjust its track to height and width values that pass as style props so long as the style props are the same, example :h10, w,10

<img width="127" alt="image" src="https://user-images.githubusercontent.com/84744653/161105546-73c76b84-3940-4efa-b7f6-64ca87bbdc04.png">
