### PR TITLE
Mat-3967

### DIFF
--- a/react/components/Button/Button.stories.js
+++ b/react/components/Button/Button.stories.js
@@ -43,6 +43,12 @@ export const Danger = () => (
     </Container>
 );
 
+export const DangerPrimary = () => (
+    <Container>
+        <Button variant="danger-primary">Button</Button>
+    </Container>
+);
+
 export const Outline = () => (
     <Container className="qpp-u-fill--blue-80">
         <Button variant="outline">Button</Button>

--- a/react/components/Button/index.js
+++ b/react/components/Button/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const VARIANTS = ["secondary", "outline", "danger", "white"];
+const VARIANTS = ["secondary", "outline", "cyan", "danger", "danger-primary", "white"];
 const SIZES = ["big"];
 
 const Button = ({

--- a/react/components/Select/index.jsx
+++ b/react/components/Select/index.jsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
             paddingBottom: 7.5,
             fontFamily: "Rubik",
             fontSize: 14,
-            borderRadius: 3,
+            borderRadius: 3
         },
     },
 });
@@ -48,7 +48,7 @@ const Select = ({
     ...rest
 }) => {
     const classes = useStyles();
-    const placehold = <span>{placeHolder?.name || "placeholder"}</span>;
+    const placehold = <span style={{ opacity: .6 }}>{placeHolder?.name || "placeholder"}</span>;
     return (
         <FormControl error={error} fullWidth>
             <InputLabel

--- a/react/components/TextField/index.jsx
+++ b/react/components/TextField/index.jsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles({
             borderRadius: 3,
             padding: "9px 14px",
             "&::placeholder": {
-                opacity: 1,
+                opacity: .6,
             },
         },
     },

--- a/react/components/Toast/Toast.stories.js
+++ b/react/components/Toast/Toast.stories.js
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { withKnobs } from "@storybook/addon-knobs";
+import Toast from './index'
+
+export default {
+    title: "Toast",
+    component: Toast,
+    decorators: [withKnobs],
+};
+
+export const SuccessToast = () => {
+    const [toastOpen, setToastOpen] = useState(false);
+    return (
+        <div style={{ height: '100vh', width: '100vw', backgroundColor: '#242424'}}>
+            <button onClick={() => setToastOpen(true)} style={{ position: 'absolute', top: '50%', left: 'calc(50% - 80px)'}}>
+                Simulate Success
+            </button>
+            <Toast
+                toastKey='toast-key'
+                testId="success-toast"
+                toastType='success'
+                open={toastOpen}
+                message='An action has successfully been completed'
+                onClose={() => setToastOpen(false)}
+                autoHideDuration={3000}
+            />
+        </div>
+    )
+}
+
+export const DangerToast = () => {
+    const [toastOpen, setToastOpen] = useState(false);
+    return (
+        <div style={{ height: '100vh', width: '100vw', backgroundColor: '#242424'}}>
+            <button onClick={() => setToastOpen(true)} style={{ position: 'absolute', top: '50%', left: 'calc(50% - 80px)'}}>
+                Simulate Danger
+            </button>
+            <Toast
+                toastKey='toast-key'
+                toastType='danger'
+                testId="danger-toast"
+                open={toastOpen}
+                message='Something has gone wrong. Please try again'
+                onClose={() => setToastOpen(false)}
+                autoHideDuration={3000}
+            />
+        </div>
+    )
+}

--- a/react/components/Toast/index.jsx
+++ b/react/components/Toast/index.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { IconButton, Snackbar } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+const Toast = ({
+    open,
+    message,
+    toastType, // 'danger | success, more later when mockups come out
+    autoHideDuration,
+    onClose,
+    testId,
+    toastKey,
+    ...rest
+}) => {
+    const dangerColor = '#D92F2F'
+    const successColor = '#4d7e23'
+    // we can map our colors and icons to make this reusable for multiple info types.
+    const colorMap = {
+        danger: dangerColor,
+        success: successColor
+    }
+    const iconMap = {
+        danger: ErrorOutlineIcon,
+        success: CheckCircleOutlineIcon
+    }
+    const selectedColor = colorMap[toastType];
+    const SelectedIcon = iconMap[toastType];
+
+    const Message = (
+    <div className='messageCont'>
+        <div>
+            <div className='errorCont'>
+            {SelectedIcon && (
+                <SelectedIcon
+                className='leftIcon'
+                />
+            )}
+            </div>
+            <p className='messageText' data-testid={testId}>
+            {message}
+            </p>
+        </div>
+        <div style={{display: 'block'}}>
+            <IconButton
+                className='icon-button'
+                aria-label="close"
+                color="inherit"
+                sx={{ p: 0}}
+                onClick={onClose}
+            >
+                <CloseIcon />
+            </IconButton>
+        </div>
+    </div>
+    )
+    return (
+        <Snackbar
+            key={toastKey ? toastKey : undefined}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            sx={{
+            overflow:'hidden',
+            color: selectedColor,
+            borderRadius: 1,
+            '& .MuiPaper-root': {
+                backgroundColor: '#fff',
+                padding: 0,
+                color: selectedColor
+            },
+            '& .MuiSvgIcon-root': {
+                color: '#242424'
+            },
+            '& .MuiSnackbarContent-message': {
+                padding: 0,
+                flexGrow: 1,
+                '.messageCont': {
+                    display: 'flex',
+                    flexDirection: 'row',
+                    flexGrow: 1,
+                    justifyContent: 'space-between',
+                    'div': {
+                        display: 'flex',
+                        '.messageText':{
+                            m: 0,
+                            p: 2.375,
+                            fontFamily: 'Rubik',
+                            fontWeight: 500,
+                            fontSize: 14
+                        },
+                        '.errorCont':{
+                            backgroundColor: selectedColor,
+                            '.leftIcon':{
+                                m: 2,
+                                color: '#fff'
+                            }
+                        },
+                        '.icon-button':{
+                            m: 2,
+                            '&. MuiSvgIcon-root': {
+                                color: '#242424'
+                            }
+                        }
+                    }
+                },
+                '& .MuiSvgIcon-root': {
+                    color: '#242424'
+
+                }
+            }
+        }}
+
+        autoHideDuration={autoHideDuration}
+        open={open}
+        onClose={onClose}
+        message={message ? Message : undefined}
+        {...rest}
+      />)
+}
+
+export default Toast;

--- a/react/components/index.js
+++ b/react/components/index.js
@@ -19,6 +19,7 @@ import TabPanel from "./Tabs/TabPanel";
 import Tabs from "./Tabs/index";
 import TextField from "./TextField";
 import Tooltip from "./Tooltip";
+import Toast from './Toast';
 import Infotip from "./Infotip";
 import Search from "./Search";
 import TextInput from "./TextInput";
@@ -132,6 +133,7 @@ export {
     TextButton,
     TextInput,
     TextField,
+    Toast,
     Dropdown,
     Tooltip,
     DSLink,

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@madie/madie-design-system",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "CC0-1.0",
       "dependencies": {
         "@cmsgov/design-system": "^2.13.0",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madie/madie-design-system",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Shared style guide across the Madie program.",
   "main": "dist/index.js",
   "homepage": "https://github.com/MeasureAuthoringTool/madie-design-system",

--- a/react/test/components/Toast.test.js
+++ b/react/test/components/Toast.test.js
@@ -1,0 +1,70 @@
+import "@testing-library/jest-dom";
+import { describe, expect, test } from "@jest/globals";
+import Toast from "../../components/Toast/index";
+import { act } from "react-dom/test-utils";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+
+import React, { useState } from "react";
+
+const ToastTester = (toastProps) => {
+    const [toastOpen, setToastOpen] = useState(false);
+    return (
+        <div>
+            <button
+                data-testid="toast-tester"
+                onClick={() => setToastOpen(true)}
+            >
+                toast tester
+            </button>
+            <Toast
+                open={toastOpen}
+                onClose={() => setToastOpen(false)}
+                {...toastProps}
+            />
+        </div>
+    )
+}
+
+describe("Toast", () => {
+    test("Danger toast renders correctly and disappears", async () => {
+        await act(async () => {
+            const { findByTestId, getByTestId, queryByText } = await render(
+                <ToastTester
+                    toastKey='toast-key'
+                    testId="danger-toast"
+                    toastType='danger'
+                    autoHideDuration={1000}
+                    message='Something has gone wrong. Please try again'
+                 />
+            );
+            const result = await findByTestId("toast-tester");
+            fireEvent.click(result);
+            const dangerToast = await getByTestId("danger-toast");
+            expect(dangerToast).toBeInTheDocument();
+            await waitFor(() => {
+                expect(queryByText('Something has gone wrong. Please try again')).not.toBeVisible()
+            })
+        });
+    });
+
+    test("Success toast renders correctly and disappears", async () => {
+        await act(async () => {
+            const { findByTestId, getByTestId, queryByText } = await render(
+                <ToastTester
+                    toastKey='toast-key'
+                    testId="success-toast"
+                    toastType='success'
+                    autoHideDuration={1000}
+                    message='Something has completed'
+                 />
+            );
+            const result = await findByTestId("toast-tester");
+            fireEvent.click(result);
+            const dangerToast = await getByTestId("success-toast");
+            expect(dangerToast).toBeInTheDocument();
+            await waitFor(() => {
+                expect(queryByText('Something has completed')).not.toBeVisible()
+            })
+        });
+    });
+});

--- a/shared/styles/qppds/components/_button.scss
+++ b/shared/styles/qppds/components/_button.scss
@@ -236,6 +236,45 @@
       padding: 1px;
     }
   }
+  // Danger-Primary / Destructive Button
+  &.qpp-c-button--danger-primary {
+    border: 1px solid $red-50;
+    background-color: $red-50;
+	color: $white;
+    font-size: $font-size-14;
+
+    &:disabled,
+    &.qpp-c-button--disabled {
+		background-color: $gray-04;
+		color: $gray-60;
+		border-color: $gray-04;
+    }
+
+    &:hover,
+    &.qpp-c-button--hover {
+		background-color: $red-60;
+		border-color: $red-60;
+    }
+
+    &:active,
+    &.qpp-c-button--active {
+      background-color: fade-out($red-50, 0.2);
+    }
+
+    &:focus,
+    &.qpp-c-button--focus {
+      border: 1px solid $red-50;
+      box-shadow: 0 0 0 4px $red-10;
+      outline: none;
+      text-decoration: none;
+    }
+
+    &.qpp-c-button--text {
+      background-color: transparent;
+      border: 1px solid transparent;
+      padding: 1px;
+    }
+  }
 }
 
 .qpp-c-button.qpp-c-button--text,


### PR DESCRIPTION
This PR adds
- reuasable toast component with danger and success presentations
- reusable danger primary button to reflect mockup
- updates to placeholders for select and textfield to present with lowered opacity.
- tests for toast components
- storybook for toast components

<img width="347" alt="image" src="https://user-images.githubusercontent.com/84744653/162302287-fc50d2a5-6a65-46de-85b7-a2dd94b0622b.png">
<img width="343" alt="image" src="https://user-images.githubusercontent.com/84744653/162302457-8d79dd61-080c-49a4-94da-2bfa1076f950.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/84744653/162302699-caf99236-caa1-4a48-83be-2b90161d48e3.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/84744653/162303206-0ecd99d5-7f06-4c96-bbe4-0c7befe56a86.png">
<img width="154" alt="image" src="https://user-images.githubusercontent.com/84744653/162304913-91c76f58-6e2e-4d71-885a-508a626b2e89.png">
