### PR TITLE
Release 1.2.18 - MAT-7015 Datefield changes

### DIFF
--- a/react/components/DateField/DateField.jsx
+++ b/react/components/DateField/DateField.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import InputLabel from "../InputLabel";
 import TextField from "../TextField";
+import { Box } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -51,54 +52,68 @@ const DateField = ({
     disabled,
     error,
     helperText,
+    containerSx = {},
+    textFieldSx = {},
     ...rest
 }) => {
+    if (containerSx === undefined || containerSx === null) {
+        containerSx = {};
+    }
+    if (textFieldSx === undefined || textFieldSx === null) {
+        textFieldSx = {};
+    }
+
     return (
         <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <InputLabel
-                data-testid={`${kebabCase(label)}`}
-                style={{ marginBottom: 0, height: 16 }}
-                sx={[
-                    {
-                        backgroundColor: "transparent",
-                        textTransform: "none",
-                        height: 17,
-                        left: 0,
-                        right: 0,
-                        top: 0,
-                        fontFamily: "Rubik",
-                        fontStyle: "normal",
-                        fontWeight: 500,
-                        fontSize: 14,
-                        color: "#333333",
-                    },
-                ]}
-            >
-                {`${label}`}
-            </InputLabel>
-            <DatePicker
-                value={value ? dayjs.utc(value) : null}
-                onChange={handleDateChange}
-                disabled={disabled}
-                slotProps={{
-                    textField: (params) => {
-                        const { InputProps } = params;
-                        InputProps["data-testid"] = id;
-                        InputProps["aria-required"] = true;
+            <Box sx={{ ...containerSx }}>
+                <InputLabel
+                    data-testid={`${kebabCase(label)}`}
+                    style={{ marginBottom: 0, height: 16 }}
+                    sx={[
+                        {
+                            backgroundColor: "transparent",
+                            textTransform: "none",
+                            height: 17,
+                            left: 0,
+                            right: 0,
+                            top: 0,
+                            fontFamily: "Rubik",
+                            fontStyle: "normal",
+                            fontWeight: 500,
+                            fontSize: 14,
+                            color: "#333333",
+                        },
+                    ]}
+                    required={rest?.required}
+                >
+                    {`${label}`}
+                </InputLabel>
+                <DatePicker
+                    value={value ? dayjs.utc(value) : null}
+                    onChange={handleDateChange}
+                    disabled={disabled}
+                    onClose={() => rest?.onBlur()}
+                    slotProps={{
+                        textField: (params) => {
+                            const { InputProps } = params;
+                            InputProps["data-testid"] = id;
+                            InputProps["aria-required"] = true;
 
-                        return {
-                            id: id,
-                            sx: dateTextFieldStyle,
-                            value: value ? dayjs.utc(value) : null,
-                            onChange: handleDateChange,
-                            //...rest,
-                            error: error,
-                            helperText: helperText,
-                        };
-                    },
-                }}
-                slots={{ textField: TextField }}
-            />
+                            return {
+                                id: id,
+                                sx: { ...dateTextFieldStyle, ...textFieldSx },
+                                value: value ? dayjs.utc(value) : null,
+                                onChange: handleDateChange,
+                                //...rest,
+                                error: error,
+                                helperText: helperText,
+                                onBlur: rest?.onBlur,
+                            };
+                        },
+                    }}
+                    slots={{ textField: TextField }}
+                />
+            </Box>
         </LocalizationProvider>
     );
 };

--- a/react/components/DateField/DateField.jsx
+++ b/react/components/DateField/DateField.jsx
@@ -145,6 +145,9 @@ DateField.propTypes = {
     id: PropTypes.string,
     error: PropTypes.bool,
     helperText: PropTypes.string,
+    required: PropTypes.bool,
+    containerSx: PropTypes.object,
+    textFieldSx: PropTypes.object,
 };
 
 export default DateField;

--- a/react/components/DateField/DateField.jsx
+++ b/react/components/DateField/DateField.jsx
@@ -52,6 +52,7 @@ const DateField = ({
     disabled,
     error,
     helperText,
+    required = false,
     containerSx = {},
     textFieldSx = {},
     ...rest
@@ -72,19 +73,38 @@ const DateField = ({
                     sx={[
                         {
                             backgroundColor: "transparent",
+                            display: "flex",
+                            flexDirection: "row-reverse",
+                            alignSelf: "baseline",
+                            justifyContent: "left",
                             textTransform: "none",
-                            height: 17,
-                            left: 0,
-                            right: 0,
-                            top: 0,
+                            // force it outside the select box
+                            position: "initial",
+                            transform: "translateX(0px) translateY(0px)",
                             fontFamily: "Rubik",
-                            fontStyle: "normal",
                             fontWeight: 500,
                             fontSize: 14,
-                            color: "#333333",
+                            color: "#333",
+                            "& .MuiInputLabel-asterisk": {
+                                color: "#AE1C1C !important",
+                                marginRight: "3px !important", //this was
+                            },
+                        },
+                        required && {
+                            transform: "translateX(-12px) translateY(0px)",
+                            "& .MuiInputLabel-asterisk": {
+                                color: "#D92F2",
+                                marginRight: "3px !important", //this was
+                            },
+                        },
+                        disabled && {
+                            color: "rgba(0,0,0,0.6)",
+                        },
+                        error && {
+                            color: "#AE1C1C !important",
                         },
                     ]}
-                    required={rest?.required}
+                    required={required}
                 >
                     {`${label}`}
                 </InputLabel>
@@ -97,7 +117,7 @@ const DateField = ({
                         textField: (params) => {
                             const { InputProps } = params;
                             InputProps["data-testid"] = id;
-                            InputProps["aria-required"] = true;
+                            InputProps["aria-required"] = required;
 
                             return {
                                 id: id,

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@madie/madie-design-system",
-    "version": "1.2.17-beta.0",
+    "version": "1.2.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@madie/madie-design-system",
-            "version": "1.2.17-beta.0",
+            "version": "1.2.18",
             "license": "CC0-1.0",
             "dependencies": {
                 "@cmsgov/design-system": "^5.0.2",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@madie/madie-design-system",
-    "version": "1.2.17-beta.0",
+    "version": "1.2.18",
     "description": "Shared style guide across the Madie program.",
     "main": "dist/index.js",
     "homepage": "https://github.com/MeasureAuthoringTool/madie-design-system",


### PR DESCRIPTION


## MADiE PR

Jira Ticket: [MAT-7015](https://jira.cms.gov/browse/MAT-7015)
(Optional) Related Tickets:

### Summary
For DateField - add several new props, update styling, and add support for onBlur
![image](https://github.com/MeasureAuthoringTool/madie-design-system/assets/94391996/61673e5c-7569-424e-bffd-88fd30978da1)


### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
