### PR TITLE
Release 1.2.67 - MAT-8780: run 'npm audit fix' to bump form-data from 4.0.3 to 4.0.4 in /react

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@madie/madie-design-system",
-    "version": "1.2.66",
+    "version": "1.2.67",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@madie/madie-design-system",
-            "version": "1.2.66",
+            "version": "1.2.67",
             "license": "CC0-1.0",
             "dependencies": {
                 "@cmsgov/design-system": "^5.0.2",

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -9202,9 +9202,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12622,14 +12622,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@madie/madie-design-system",
-    "version": "1.2.66",
+    "version": "1.2.67",
     "description": "Shared style guide across the Madie program.",
     "main": "dist/index.js",
     "homepage": "https://github.com/MeasureAuthoringTool/madie-design-system",

--- a/react/test/components/RichTextEditor.test.js
+++ b/react/test/components/RichTextEditor.test.js
@@ -113,4 +113,21 @@ describe("RichTextEditor Component", () => {
         // Ensure the innerHTML matches the sanitized version of the content
         expect(readOnlyContent.innerHTML).toBe(DOMPurify.sanitize(content));
     });
+
+    it("displays helper text when error is true", () => {
+        render(
+            <RichTextEditor
+                id="test-editor"
+                label="Test Label"
+                content={null}
+                helperText="This field is required."
+                required={true}
+                error={true}
+                onChange={mockOnChange}
+            />
+        );
+
+        const helperTextElement = screen.getByTestId("test-editor-helper-text");
+        expect(helperTextElement).toHaveTextContent("This field is required.");
+    });
 });


### PR DESCRIPTION
## MADiE PR

Resolves https://github.com/MeasureAuthoringTool/madie-design-system/pull/346

Jira Ticket: [MAT-8780](https://jira.cms.gov/browse/MAT-8780)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
